### PR TITLE
Make noop available to the programmer.

### DIFF
--- a/EmitCactus/__init__.py
+++ b/EmitCactus/__init__.py
@@ -10,7 +10,7 @@ from .dsl.use_indices import parities
 
 from .dsl.use_indices import D, div, to_num, IndexedSubstFnType, MkSubstType, Param, ThornFunction, ScheduleBin, ThornDef, \
        set_dimension, get_dimension, lookup_pair, subst_tensor_xyz, mk_pair, \
-       stencil,DD,DDI,\
+       noop,stencil,DD,DDI,\
        ui, uj, uk, ua, ub, uc, ud, u0, u1, u2, u3, u4, u5, \
        li, lj, lk, la, lb, lc, ld, l0, l1, l2, l3, l4, l5
 from .dsl.sympywrap import Applier,sqrt,cbrt,log,exp,Pow,PowType,UFunc,diff,\
@@ -31,7 +31,7 @@ __all__ = [
     "sin", "cos",
     "D", "div", "to_num", "IndexedSubstFnType", "MkSubstType", "Param", "ThornFunction", "ScheduleBin", "ThornDef",
     "set_dimension", "get_dimension", "lookup_pair", "subst_tensor_xyz", "mk_pair",
-    "stencil","DD","DDI",
+    "noop","stencil","DD","DDI",
     "ui", "uj", "uk", "ua", "ub", "uc", "ud", "u0", "u1", "u2", "u3", "u4", "u5",
     "li", "lj", "lk", "la", "lb", "lc", "ld", "l0", "l1", "l2", "l3", "l4", "l5",
     "Applier","sqrt","cbrt","log","exp","Pow","PowType","UFunc","diff",

--- a/EmitCactus/dsl/use_indices.py
+++ b/EmitCactus/dsl/use_indices.py
@@ -26,7 +26,7 @@ from EmitCactus.util import OrderedSet, ScheduleBinEnum
 __all__ = ["D", "div", "to_num", "IndexedSubstFnType", "MkSubstType", "Param", "ThornFunction", "ScheduleBin",
            "ThornDef",
            "set_dimension", "get_dimension", "lookup_pair", "subst_tensor", "subst_tensor_xyz", "mk_pair",
-           "stencil", "DD", "DDI",
+           "noop", "stencil", "DD", "DDI",
            "ui", "uj", "uk", "ua", "ub", "uc", "ud", "u0", "u1", "u2", "u3", "u4", "u5",
            "li", "lj", "lk", "la", "lb", "lc", "ld", "l0", "l1", "l2", "l3", "l4", "l5"]
 
@@ -1607,7 +1607,7 @@ class ThornDef:
             elif expr.func == DD:
                 if len(expr.args) != 1:
                     raise DslException(expr)
-                arg = mk_sten(idx, idx0, expr.args[0])
+                arg = mk_sten(idx_map, expr.args[0])
                 if arg == l0:
                     return DX
                 elif arg == l1:
@@ -1626,6 +1626,9 @@ class ThornDef:
                 elif arg == l2:
                     return DZI
                 assert False
+            elif expr.func == noop:
+                arg = mk_sten(idx_map, expr.args[0])
+                return noop(arg)
             else:
                 raise DslException("Bad Func")
 
@@ -1699,7 +1702,7 @@ class ThornDef:
                     result = mk_sten({idx1: idx10, idx2: idx20}, expr)
                     self.funs2[(func, idx10, idx20)] = result
 
-        return mkFunction(func_name)
+        return func
 
     class DeclOptionalArgs(TypedDict, total=False):
         centering: Centering

--- a/recipes/Cottonmouth/bssnok.py
+++ b/recipes/Cottonmouth/bssnok.py
@@ -25,13 +25,10 @@ div_diss = cottonmouth_bssnok.mk_stencil(
     "div_diss",
     la,
     Rational(1, 64) * DDI(la) * (
-        stencil(-3*la)
-        - 6.0 * stencil(-2*la)
-        + 15.0 * stencil(-la)
-        - 20.0 * stencil(0) +
-        15.0 * stencil(la)
-        - 6.0 * stencil(2*la)
-        + stencil(3*la)
+        noop(stencil(-3*la) + stencil(3*la))
+        - 6.0 * noop(stencil(-2*la) + stencil(2*la))
+        + 15.0 * noop(stencil(-la) + stencil(la))
+        - 20.0 * stencil(0)
     )
 )
 


### PR DESCRIPTION
Because SymPy tends to undo/ignore programmer suggestions for the grouping of variables, we offer the "noop" function (a function which does nothing) to coerce grouping. Previously, this functionality was only used by the default derivative function.