### PR TITLE
This gets Z4c rhs down to 25 seconds.

### DIFF
--- a/EinsteinEngine/dsl/use_indices.py
+++ b/EinsteinEngine/dsl/use_indices.py
@@ -1535,8 +1535,41 @@ class ThornFunction:
             if util.verbose():
                 eqn_list.dump()
 
+    def _mk_extra(self, ivar:Indexed)->Indexed:
+        td = self.thorn_def
+        td.name_index += 1
+        base = ivar.args[0]
+        assert type(base) == IndexedBase
+        name = base.name + "_extra_" + str(td.name_index)
+        inds : List[Idx] = list()
+        for ind in ivar.args[1:]:
+            assert type(ind) == Idx
+            inds.append(ind)
+        syms = list()
+        asyms = list()
+        for sym in td.symmetries.sd[base]:
+            ind1, ind2, sign = sym
+            idx1 = inds[ind1]
+            idx2 = inds[ind2]
+            if sign > 0:
+                syms  += [(idx1, idx2)]
+            else:
+                asyms += [(idx1, idx2)]
+        new_var : IndexedBase = td.decl(name, td.declarations[base.name].indices, symmetries=syms, anti_symmetries=asyms)
+        new_ivar = new_var[*inds]
+        assert type(new_ivar) == Indexed
+        return new_ivar
+
     @multimethod
-    def add_eqn(self, lhs: Indexed, rhs: Expr) -> None:
+    def add_eqn(self, lhs: Indexed, rhs: Expr, *extras: Expr) -> None:
+
+        # Handle extras: These are implicitly declared temporaries
+        # that are used to split up the calculation into smaller pieces.
+        for extra in extras:
+            extra_lhs = self._mk_extra(lhs)
+            rhs += extra_lhs
+            self.add_eqn(extra_lhs, extra)
+
         check_indices(rhs, self.thorn_def.defn)
 
         if self.been_baked:
@@ -1756,6 +1789,7 @@ class ThornDef:
         if not _is_valid_c_identifier(name):
             raise DslException(f"Thorn name '{name}' is not a valid C identifier")
 
+        self.name_index: int = 0
         self.fun_args: Dict[str, int] = dict()
         self.run_simplify = run_simplify
         self.coords: List[Symbol] = list()
@@ -2549,7 +2583,7 @@ class ThornDef:
         else:
             indexed_symbol = None
 
-        assert basename not in self.gfs
+        assert basename not in self.gfs, f"basename: {basename}"
         self.gfs[basename] = the_symbol
         self.defn[basename] = (basename, list(indices))
         self.centering[basename] = centering

--- a/recipes/Cottonmouth/Z4c.py
+++ b/recipes/Cottonmouth/Z4c.py
@@ -850,21 +850,25 @@ fun_z4c_rhs.add_eqn(
     gt[li, lj] * gt[ul, uk] * D(chi, lk) * D(chi, ll)
 )
 
-fun_z4c_rhs.soft_split()
+fun_z4c_rhs.split_loop()
 
 # Eq (9) of [1]
 fun_z4c_rhs.add_eqn(
     Rt_tmp[li, lj],
     - Rational(1, 2) * gt[ul, um] * D(gt[li, lj], ll, lm)
+    , # +
     + Rational(1, 2) * (
         + gt[lk, li] * D(evo_Gammat[uk], lj)
         + gt[lk, lj] * D(evo_Gammat[uk], li)
     )
+    , # +
     + Rational(1, 2) * (
         + Gammatd[uk] * Gammat[li, lj, lk]
         + Gammatd[uk] * Gammat[lj, li, lk]
     )
 )
+
+fun_z4c_rhs.split_loop()
 
 fun_z4c_rhs.add_eqn(
     Rt[li, lj],
@@ -878,6 +882,8 @@ fun_z4c_rhs.add_eqn(
     R[li, lj],
     Rchi[li, lj] + Rt[li, lj]
 )
+
+fun_z4c_rhs.soft_split()
 
 # Eq. (6) of [1]
 fun_z4c_rhs.add_eqn(
@@ -894,6 +900,7 @@ fun_z4c_rhs.add_eqn(
     # Matter
     + use_matter_terms * (-evo_lapse) * 8 * pi * rho
 )
+
 
 # Eq. (4) of [1]
 fun_z4c_rhs.add_eqn(
@@ -935,7 +942,7 @@ fun_z4c_rhs.add_eqn(
     + use_matter_terms * 4 * pi * evo_lapse * (trS + rho)
 )
 
-fun_z4c_rhs.soft_split()
+fun_z4c_rhs.split_loop()
 
 # Eq. (5) of [1]
 fun_z4c_rhs.add_eqn(
@@ -959,8 +966,6 @@ fun_z4c_rhs.add_eqn(
     + use_matter_terms * (-16) * pi * evo_lapse * gt[ui, uj] * Svec[lj]
 )
 
-fun_z4c_rhs.split_loop()
-
 # Eq. (2) of [1]
 fun_z4c_rhs.add_eqn(
     gt_rhs[li, lj],
@@ -971,6 +976,7 @@ fun_z4c_rhs.add_eqn(
     # Advection
     + evo_shift[uk] * D(gt[li, lj], lk)
 )
+fun_z4c_rhs.split_loop()
 
 fun_z4c_rhs.add_eqn(
     At_rhs[li, lj],
@@ -1023,6 +1029,8 @@ fun_z4c_diss.add_eqn(
     )
 )
 
+fun_z4c_diss.split_loop()
+
 chi_rhs_diss = cottonmouth_Z4c.overwrite(chi_rhs)
 fun_z4c_diss.add_eqn(
     chi_rhs_diss,
@@ -1032,6 +1040,8 @@ fun_z4c_diss.add_eqn(
         + div_diss(chi, l2)
     )
 )
+
+fun_z4c_diss.split_loop()
 
 trK_rhs_diss = cottonmouth_Z4c.overwrite(trK_rhs)
 fun_z4c_diss.add_eqn(
@@ -1043,6 +1053,8 @@ fun_z4c_diss.add_eqn(
     )
 )
 
+fun_z4c_diss.split_loop()
+
 GammaHat_rhs_diss = cottonmouth_Z4c.overwrite(evo_Gammat_rhs)
 fun_z4c_diss.add_eqn(
     GammaHat_rhs_diss[ui],
@@ -1052,6 +1064,8 @@ fun_z4c_diss.add_eqn(
         + div_diss(evo_Gammat[ui], l2)
     )
 )
+
+fun_z4c_diss.split_loop()
 
 gt_rhs_diss = cottonmouth_Z4c.overwrite(gt_rhs)
 fun_z4c_diss.add_eqn(
@@ -1063,6 +1077,8 @@ fun_z4c_diss.add_eqn(
     )
 )
 
+fun_z4c_diss.split_loop()
+
 At_rhs_diss = cottonmouth_Z4c.overwrite(At_rhs)
 fun_z4c_diss.add_eqn(
     At_rhs_diss[li, lj],
@@ -1073,6 +1089,8 @@ fun_z4c_diss.add_eqn(
     )
 )
 
+fun_z4c_diss.split_loop()
+
 evo_lapse_rhs_diss = cottonmouth_Z4c.overwrite(evo_lapse_rhs)
 fun_z4c_diss.add_eqn(
     evo_lapse_rhs_diss,
@@ -1082,6 +1100,8 @@ fun_z4c_diss.add_eqn(
         + div_diss(evo_lapse, l2)
     )
 )
+
+fun_z4c_diss.split_loop()
 
 evo_shift_rhs_diss = cottonmouth_Z4c.overwrite(evo_shift_rhs)
 fun_z4c_diss.add_eqn(
@@ -1247,8 +1267,10 @@ cottonmouth_Z4c.bake(
     temporary_promotion_strategy=promote_none(),
     do_madd=False,
     do_recycle_temporaries=True,
-    cse_optimization_level=CseOptimizationLevel.Fast,
-    soft_split_retainment_strategy=retain_percentile(.7)
+    cse_optimization_level=CseOptimizationLevel.Optimal,
+    soft_split_retainment_strategy=retain_rank(50),
+    ordering_fn=functools.partial(
+        prioritize_rare_symbols, use_sqrt=False, consider_frequency=True, complexity_factor=0.0)
 )
 
 ###

--- a/recipes/Cottonmouth/Z4c.py
+++ b/recipes/Cottonmouth/Z4c.py
@@ -1270,7 +1270,7 @@ cottonmouth_Z4c.bake(
     cse_optimization_level=CseOptimizationLevel.Optimal,
     soft_split_retainment_strategy=retain_rank(50),
     ordering_fn=functools.partial(
-        prioritize_rare_symbols, use_sqrt=False, consider_frequency=True, complexity_factor=0.0)
+        prioritize_rare_symbols, consider_frequency=True, complexity_factor=0.0)
 )
 
 ###


### PR DESCRIPTION
This branch has a modification to use_indices that allows people to automatically make temporaries. It was important to getting down to 25 sec.

tf.add_eqn(foo[la, lb],
    bar[la, lb]+Rational(2,3)*baz[la,lb]
    , # creates a temporary for the term above, does an add_eqn for it, and adds the temporary to the current eqn.
    bar[lc, lb]*Metricg[uc, la]
)